### PR TITLE
Add xcreensaver back and launch daemon when starting.

### DIFF
--- a/preferences
+++ b/preferences
@@ -554,7 +554,7 @@ IconPath="/usr/share/icons/Adwaita/16x16/apps:/usr/share/icons/hicolor/16x16/app
 # NewMailCommand=""
 
 #  Command to lock display/screensaver
-LockCommand="xlock -mousemotion"
+LockCommand="xscreensaver-command -lock || xlock -mousemotion"
 
 #  Command to run on clock
 # ClockCommand="xclock -name icewm -title Clock"

--- a/startup
+++ b/startup
@@ -10,3 +10,7 @@ for i in /usr/lib/polkit-gnome-authentication-agent-1 \
 		break # One is enough
 	fi
 done;
+
+# Start xscreensaver daemon
+
+[ -x /usr/bin/xscreensaver ] && /usr/bin/xscreensaver > /dev/null &


### PR DESCRIPTION
xlock is a monolithic binary, any crash in screensaver hacks causes
unfixable unlock race.