### PR TITLE
Add the adwaita legacy path to the IconPath.

### DIFF
--- a/preferences
+++ b/preferences
@@ -539,7 +539,7 @@
 # NetWorkAreaBehaviour=0 # [0-2]
 
 #  Icon search path (colon separated)
-IconPath="/usr/share/icons/Adwaita/16x16/apps:/usr/share/icons/hicolor/16x16/apps:/usr/share/pixmaps"
+IconPath="/usr/share/icons/Adwaita/16x16/legacy:/usr/share/icons/Adwaita/16x16/apps:/usr/share/icons/hicolor/16x16/apps:/usr/share/pixmaps"
 
 #  Mailbox path (use $MAIL instead)
 # MailBoxPath=""


### PR DESCRIPTION
adwaita-icon-theme has its main icon updated to symbolic style,
while icewm's design is more suitable for the legacy icons.