### PR TITLE
Update web browser icon.

### DIFF
--- a/preferences
+++ b/preferences
@@ -539,7 +539,7 @@ MenuMouseTracking=1 # 0/1
 # NetWorkAreaBehaviour=0 # [0-2]
 
 #  Icon search path (colon separated)
-IconPath="/usr/share/icons/Adwaita/16x16/legacy:/usr/share/icons/Adwaita/16x16/apps:/usr/share/icons/hicolor/16x16/apps:/usr/share/pixmaps"
+IconPath="/usr/share/icons/Adwaita/symbolic/legacy:/usr/share/icons/hicolor/16x16/apps:/usr/share/pixmaps"
 
 #  Mailbox path (use $MAIL instead)
 # MailBoxPath=""

--- a/toolbar
+++ b/toolbar
@@ -5,5 +5,5 @@
 # (re)install icewm.
 #
 prog xterm xterm xterm
-prog "Web browser" web-browser xdg-open about:blank
+prog "Web browser" web-browser-symbolic xdg-open about:blank
 


### PR DESCRIPTION
The Adwaita theme does not provide much legacy apps icon now, redirect icewm web-browser icon to the right place. See:

https://gitlab.gnome.org/GNOME/adwaita-icon-theme/-/issues/163 https://gitlab.gnome.org/GNOME/adwaita-icon-theme/-/merge_requests/34/