### PR TITLE
Use 1920x1200 symlink by default

### DIFF
--- a/preferences
+++ b/preferences
@@ -1349,7 +1349,7 @@ DesktopBackgroundScaled=1 # 0/1
 # DesktopBackgroundColor="rgb:00/20/40"
 
 #  Desktop background image
-DesktopBackgroundImage="/usr/share/wallpapers/SLEdefault/contents/images/1920x1080.png"
+DesktopBackgroundImage="/usr/share/wallpapers/SLEdefault/contents/images/1920x1200.png"
 
 #  Color to announce for semi-transparent windows
 # DesktopTransparencyColor=""


### PR DESCRIPTION
* we'll eventually change it to default.png later however, with this change we're consistent with xfce, kde etc

* The 1080 symlink is no longer available https://github.com/openSUSE/branding/pull/162